### PR TITLE
Disable snap scrolling in mobile

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -18,7 +18,7 @@ const { title } = Astro.props;
 ---
 
 <!doctype html>
-<html lang="en" class="snap-mandatory snap-y">
+<html lang="en" class="md:snap-mandatory md:snap-y">
   <head>
     <meta charset="UTF-8" />
     <meta name="description" content="Astro description" />


### PR DESCRIPTION
Disabled snap scrolling on mobile devices to allow a better visualization of the content.